### PR TITLE
fix: handle missing SeriesId/SeasonId/IndexNumber for non-episode media types

### DIFF
--- a/EmbyToAlist/providers/media_server/emby/helpers.py
+++ b/EmbyToAlist/providers/media_server/emby/helpers.py
@@ -14,9 +14,9 @@ def build_item_info(item: dict) -> ItemInfo:
         item_type = 'episode'
 
     tvshows_info = TVShowsInfo(
-        series_id=int(item['SeriesId']),
-        season_id=int(item['SeasonId']),
-        index_number=int(item['IndexNumber'])
+        series_id=int(item.get('SeriesId', 0)),
+        season_id=int(item.get('SeasonId', 0)),
+        index_number=int(item.get('IndexNumber', 0))
     ) if item_type == 'episode' else None
 
     return ItemInfo(


### PR DESCRIPTION
When playing media from a library typed as Home Videos/Photos, Emby does not return SeriesId, SeasonId, or IndexNumber fields. This causes a KeyError in build_item_info(), resulting in a 500 error.

Fix: use .get() with default 0 for all three fields.